### PR TITLE
[PSP-2033] Expose AWS keys in the SQS protocol

### DIFF
--- a/gatling-decoupled-response/src/main/scala/io/gatling/decoupled/protocol/SqsProtocol.scala
+++ b/gatling-decoupled-response/src/main/scala/io/gatling/decoupled/protocol/SqsProtocol.scala
@@ -22,6 +22,7 @@ import io.gatling.core.CoreComponents
 import io.gatling.core.config.GatlingConfiguration
 import io.gatling.core.protocol.{ Protocol, ProtocolComponents, ProtocolKey }
 import io.gatling.core.session.Session
+import io.gatling.decoupled.ingestion.SqsReader.AwsKeys
 import io.gatling.decoupled.ingestion.{ SqsMessageProcessor, SqsReader }
 import io.gatling.decoupled.state.{ ActorBasedPendingRequestsState, PendingRequestsState }
 import software.amazon.awssdk.regions.Region
@@ -46,7 +47,7 @@ object SqsProtocol {
         new SqsMessageProcessor(state),
         protocol.awsRegion,
         protocol.queueUrl.toExternalForm,
-        None
+        protocol.awsKeys
       )(coreComponents.actorSystem)
 
       sqsReader.run
@@ -60,7 +61,8 @@ object SqsProtocol {
       new URL(queueUrl),
       Region.of(awsRegion),
       10.minutes,
-      30.seconds
+      30.seconds,
+      None
     )
   }
 
@@ -70,7 +72,8 @@ final case class SqsProtocol(
     queueUrl: URL,
     awsRegion: Region,
     decoupledResponseTimeout: FiniteDuration,
-    processingTimeout: FiniteDuration
+    processingTimeout: FiniteDuration,
+    awsKeys: Option[AwsKeys]
 ) extends Protocol
 
 final case class SqsComponents(pendingRequests: PendingRequestsState, reader: SqsReader) extends ProtocolComponents {

--- a/gatling-decoupled-response/src/main/scala/io/gatling/decoupled/protocol/SqsProtocolBuilder.scala
+++ b/gatling-decoupled-response/src/main/scala/io/gatling/decoupled/protocol/SqsProtocolBuilder.scala
@@ -17,6 +17,7 @@
 package io.gatling.decoupled.protocol
 
 import com.softwaremill.quicklens._
+import io.gatling.decoupled.ingestion.SqsReader.{ AwsKeys, Secret }
 
 import scala.concurrent.duration._
 
@@ -36,6 +37,24 @@ final case class SqsProtocolBuilder(protocol: SqsProtocol) {
   def decoupledResponseTimeoutSeconds(seconds: Int): SqsProtocolBuilder = this.modify(_.protocol.decoupledResponseTimeout).setTo(seconds.seconds)
 
   def processingTimeout(seconds: Int): SqsProtocolBuilder = this.modify(_.protocol.processingTimeout).setTo(seconds.seconds)
+
+  def awsAccessKeyId(key: String): SqsProtocolBuilder = {
+    val current = protocol.awsKeys.getOrElse(AwsKeys.empty)
+    this
+      .modify(_.protocol.awsKeys)
+      .setTo(
+        Some(current.copy(accessKeyId = key))
+      )
+  }
+
+  def awsSecretAccessKey(secret: String): SqsProtocolBuilder = {
+    val current = protocol.awsKeys.getOrElse(AwsKeys.empty)
+    this
+      .modify(_.protocol.awsKeys)
+      .setTo(
+        Some(current.copy(secretAccessKey = Secret(secret)))
+      )
+  }
 
   def build: SqsProtocol = protocol
 

--- a/gatling-decoupled-response/src/main/scala/io/gatling/decoupled/protocol/SqsProtocolBuilder.scala
+++ b/gatling-decoupled-response/src/main/scala/io/gatling/decoupled/protocol/SqsProtocolBuilder.scala
@@ -36,7 +36,7 @@ final case class SqsProtocolBuilder(protocol: SqsProtocol) {
 
   def decoupledResponseTimeoutSeconds(seconds: Int): SqsProtocolBuilder = this.modify(_.protocol.decoupledResponseTimeout).setTo(seconds.seconds)
 
-  def processingTimeout(seconds: Int): SqsProtocolBuilder = this.modify(_.protocol.processingTimeout).setTo(seconds.seconds)
+  def processingTimeoutSeconds(seconds: Int): SqsProtocolBuilder = this.modify(_.protocol.processingTimeout).setTo(seconds.seconds)
 
   def awsAccessKeyId(key: String): SqsProtocolBuilder = {
     val current = protocol.awsKeys.getOrElse(AwsKeys.empty)

--- a/gatling-decoupled-response/src/test/scala/io/gatling/decoupled/action/compile/DecoupledResponseCompileTest.scala
+++ b/gatling-decoupled-response/src/test/scala/io/gatling/decoupled/action/compile/DecoupledResponseCompileTest.scala
@@ -24,7 +24,12 @@ class DecoupledResponseCompileTest extends Simulation {
 
   private val httpProtocol = http
 
-  private val sqsProtocol = sqs("eu-west-1", "https://sqs.eu-west-1.amazonaws.com/481516234200/queue")
+  private val sqsProtocol =
+    sqs("eu-west-1", "https://sqs.eu-west-1.amazonaws.com/481516234200/queue")
+      .awsAccessKeyId("id")
+      .awsSecretAccessKey("secret")
+      .decoupledResponseTimeoutSeconds(10)
+      .processingTimeoutSeconds(5)
 
   private val decoupledScenario = scenario("Scn")
     .exec(


### PR DESCRIPTION
I needed this as because of the way gatling runs scenarios, to pass the aws keys as local env variables is not easy (is it even possible?).
